### PR TITLE
Remove mitt dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,5 @@
       "enzyme-to-json/serializer"
     ]
   },
-  "dependencies": {
-    "mitt": "^1.1.3"
-  }
+  "dependencies": {}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2593,10 +2593,6 @@ minimist@~0.0.1:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
 
-mitt@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/mitt/-/mitt-1.1.3.tgz#528c506238a05dce11cd914a741ea2cc332da9b8"
-
 "mkdirp@>=0.5 0", mkdirp@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"


### PR DESCRIPTION
`mitt` is not required and does not need to be included.